### PR TITLE
Updates for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,8 @@ Docker Compose. Used with Docker Swarm, the cluster can be hosted on multiple se
 The topology of the sample cluster is using 1 catalog server, 3 runtime servers, 1 inbound and 1
 outbound server. It can be modified by changing the file `docker-compose.yaml`.
 
+On MacOS, the default docker daemon setting is 2 CPUs with 2 GB of memory. This setting is insufficient to run the DSI cluster. Make sure that you set to a higher value. For example, 6 CPUs with 12 GB of memory if your machine has the capability. The setting can be modified at Docker > Preferences... > Advanced section.
+
 To start the DSI cluster:
 ```sh
 cd $DSI_DOCKER_GIT/dsi-runtime/samples/cluster

--- a/dsi-runtime/samples/cluster/solution_deploy.sh
+++ b/dsi-runtime/samples/cluster/solution_deploy.sh
@@ -10,6 +10,10 @@ function get_ip {
         echo `docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' $1`
 }
 
+function get_mac_port {
+        echo `docker inspect -f '{{ (index (index .NetworkSettings.Ports "9443/tcp") 0).HostPort }}' $1`
+}
+
 if [ -z "$1" ]; then
         print_usage
         exit 1
@@ -30,13 +34,42 @@ INBOUND=`get_ip dsi-runtime-inbound`
 echo "CONTAINER1=$CONTAINER1"
 echo "CONTAINER2=$CONTAINER2"
 echo "CONTAINER3=$CONTAINER3"
+echo "INBOUND =$INBOUND"
+
+
+if [[ "$OSTYPE" == "darwin"* ]]; then
+	CONTAINER1_PORT=`get_mac_port dsi-runtime-container1`
+	CONTAINER2_PORT=`get_mac_port dsi-runtime-container2`
+	CONTAINER3_PORT=`get_mac_port dsi-runtime-container3`
+	INBOUND_PORT=`get_mac_port dsi-runtime-inbound`
+
+    echo "CONTAINER1_PORT=$CONTAINER1_PORT"
+    echo "CONTAINER2_PORT=$CONTAINER2_PORT"
+    echo "CONTAINER3_PORT=$CONTAINER3_PORT"
+    echo "INBOUND_PORT=$INBOUND_PORT"
+fi
+
 
 SOL_DEPLOY="$SRC_DIR/../solution_deploy.sh"
 
-$SOL_DEPLOY $DSI_HOME $CONTAINER1 9443 $ESA
-$SOL_DEPLOY $DSI_HOME $CONTAINER2 9443 $ESA
-$SOL_DEPLOY $DSI_HOME $CONTAINER3 9443 $ESA
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    $SOL_DEPLOY $DSI_HOME localhost $CONTAINER1_PORT $ESA
+	$SOL_DEPLOY $DSI_HOME localhost $CONTAINER2_PORT $ESA
+    $SOL_DEPLOY $DSI_HOME localhost $CONTAINER3_PORT $ESA
+else
+	$SOL_DEPLOY $DSI_HOME $CONTAINER1 9443 $ESA
+	$SOL_DEPLOY $DSI_HOME $CONTAINER2 9443 $ESA
+	$SOL_DEPLOY $DSI_HOME $CONTAINER3 9443 $ESA
+fi
+
+
+echo "calling connectivity deploy to inbound"
 
 CONN_DEPLOY="$SRC_DIR/../conn_deploy.sh"
 
-$CONN_DEPLOY $DSI_HOME $INBOUND 9443 $ESA $INCONN
+
+if [[ "$OSTYPE" == "darwin"* ]]; then
+	$CONN_DEPLOY $DSI_HOME localhost $INBOUND_PORT $ESA $INCONN
+else
+	$CONN_DEPLOY $DSI_HOME $INBOUND 9443 $ESA $INCONN
+fi

--- a/dsi-runtime/samples/cluster/solution_deploy.sh
+++ b/dsi-runtime/samples/cluster/solution_deploy.sh
@@ -10,7 +10,7 @@ function get_ip {
         echo `docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' $1`
 }
 
-function get_mac_port {
+function get_host_port {
         echo `docker inspect -f '{{ (index (index .NetworkSettings.Ports "9443/tcp") 0).HostPort }}' $1`
 }
 
@@ -34,21 +34,19 @@ INBOUND=`get_ip dsi-runtime-inbound`
 echo "CONTAINER1=$CONTAINER1"
 echo "CONTAINER2=$CONTAINER2"
 echo "CONTAINER3=$CONTAINER3"
-echo "INBOUND =$INBOUND"
-
+echo "INBOUND=$INBOUND"
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
-	CONTAINER1_PORT=`get_mac_port dsi-runtime-container1`
-	CONTAINER2_PORT=`get_mac_port dsi-runtime-container2`
-	CONTAINER3_PORT=`get_mac_port dsi-runtime-container3`
-	INBOUND_PORT=`get_mac_port dsi-runtime-inbound`
+	CONTAINER1_PORT=`get_host_port dsi-runtime-container1`
+	CONTAINER2_PORT=`get_host_port dsi-runtime-container2`
+	CONTAINER3_PORT=`get_host_port dsi-runtime-container3`
+	INBOUND_PORT=`get_host_port dsi-runtime-inbound`
 
     echo "CONTAINER1_PORT=$CONTAINER1_PORT"
     echo "CONTAINER2_PORT=$CONTAINER2_PORT"
     echo "CONTAINER3_PORT=$CONTAINER3_PORT"
     echo "INBOUND_PORT=$INBOUND_PORT"
 fi
-
 
 SOL_DEPLOY="$SRC_DIR/../solution_deploy.sh"
 
@@ -62,11 +60,9 @@ else
 	$SOL_DEPLOY $DSI_HOME $CONTAINER3 9443 $ESA
 fi
 
-
 echo "calling connectivity deploy to inbound"
 
 CONN_DEPLOY="$SRC_DIR/../conn_deploy.sh"
-
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
 	$CONN_DEPLOY $DSI_HOME localhost $INBOUND_PORT $ESA $INCONN

--- a/dsi-runtime/templates/servers/dsi-runtime-container/jvm.options
+++ b/dsi-runtime/templates/servers/dsi-runtime-container/jvm.options
@@ -6,13 +6,13 @@
 -DX10_OSGI=LATESTVERSION
 -Dcom.ibm.xs.xio.transport.disableSSL=true
 # For container servers using the XIO transport, configure a size limit for java.nio direct byte buffers.
--XX:MaxDirectMemorySize=2g
+-XX:MaxDirectMemorySize=256m
 # Please see the platform specific reference section of
 # http://www-01.ibm.com/support/knowledgecenter/SSYKE2_8.0.0/welcome/welcome_javasdk_version.html
 # for more details about the -Xgcpolicy and -Xmx settings.
 -Xgcpolicy:balanced
--Xms8g
--Xmx8g
+-Xms1g
+-Xmx1g
 # Bypass blueprint EBA transaction interceptor
 -Dcom.ibm.ws.eba.blueprint.transform.impl.RestrictAddingBundle=true
 # When using collectives, please refer to http://www.ibm.com/support/knowledgecenter/SSEQTP_8.5.5/com.ibm.websphere.wlp.nd.multiplatform.doc/ae/twlp_sec_nist.html


### PR DESCRIPTION
1) Added note in readme that the default docker daemon settings must be increased for MacOS environment when running DSI cluster
2) Reduced the default memory setting in dsi-runtime-container template
3) Modified the deployment script that the hostport is used if on MacOS.