### PR TITLE
Add support for build on cygwin.

### DIFF
--- a/dsi-runtime/build.sh
+++ b/dsi-runtime/build.sh
@@ -42,7 +42,7 @@ mkdir -p "$BUILD_DIR_DSI_RUNTIME"
 echo "Copying DSI from $DSI_HOME_RUNTIME to $BUILD_DIR_DSI_RUNTIME."
 cp -rp "$DSI_HOME_RUNTIME/"* "$BUILD_DIR_DSI_RUNTIME"
 
-if [[ "$OSTYPE" != "darwin"* ]]; then
+if [[ "$OSTYPE" != "darwin"* ]] && [[ "$OSTYPE" != "cygwin" ]]; then
         echo "Copying JDK to $BUILD_DIR_DSI."
         cp -rp "$DSI_HOME/jdk" "$BUILD_DIR_DSI"
 fi
@@ -62,7 +62,7 @@ cp -rp $DSI_TEMPLATES/servers "$BUILD_DIR_DSI_RUNTIME/wlp/templates/"
 echo "Copying docker container start script to $BUILD_DIR"
 cp "$SRC_DIR/start.sh" "$BUILD_DIR"
 
-if [[ "$OSTYPE" == "darwin"* ]]; then
+if [[ "$OSTYPE" == "darwin"* ]] || [[ "$OSTYPE" == "cygwin" ]]; then
         cp "$SRC_DIR/Dockerfile.darwin" "$BUILD_DIR"/Dockerfile
 else
         echo "Use default dockerfile"
@@ -73,7 +73,11 @@ else
         fi
 fi
 
-docker build -t "$DOCKER_IMAGE_NAME" "$BUILD_DIR"
+if [[ "$OSTYPE" == "cygwin" ]]; then
+    docker build -t "$DOCKER_IMAGE_NAME" `cygpath -m "$BUILD_DIR"`
+else
+    docker build -t "$DOCKER_IMAGE_NAME" "$BUILD_DIR"
+fi
 
 echo "The docker image $DOCKER_IMAGE_NAME has been created."
 


### PR DESCRIPTION
- Java used from a parent image
- Use the real windows path for docker toolbox on windows. 