### PR TITLE
Update wlp/etc/server.env at build time

### DIFF
--- a/dsi-runtime/Dockerfile
+++ b/dsi-runtime/Dockerfile
@@ -7,9 +7,15 @@ RUN apt-get -y dist-upgrade
 
 COPY start.sh /root/
 
+
 RUN mkdir -p /opt
 ADD /opt /opt
 
 RUN sed -i "s/\/bin\/sh/\/bin\/bash/g" "/opt/dsi/runtime/wlp/bin/xscmd.sh"
+
+COPY updateserverenv.sh /root/
+RUN chmod u+x /root/updateserverenv.sh
+RUN /root/updateserverenv.sh
+
 
 CMD /root/start.sh

--- a/dsi-runtime/build.sh
+++ b/dsi-runtime/build.sh
@@ -57,6 +57,7 @@ cp -rp $DSI_TEMPLATES/servers "$BUILD_DIR_DSI_RUNTIME/wlp/templates/"
 
 echo "Copying docker container start script to $BUILD_DIR"
 cp "$SRC_DIR/start.sh" "$BUILD_DIR"
+cp "$SRC_DIR/updateserverenv.sh" "$BUILD_DIR"
 
 cp "$SRC_DIR/Dockerfile" "$BUILD_DIR"
 

--- a/dsi-runtime/start.sh
+++ b/dsi-runtime/start.sh
@@ -34,7 +34,6 @@ INTERNAL_IP=`hostname -I| sed 's/ //g'`
 
 if [ ! -f "$SRV_XML" ]; then
         echo "Create the DSI server $DSI_TEMPLATE"
-        echo "JAVA_HOME=$JAVA_HOME" > /opt/dsi/runtime/wlp/etc/server.env
         /opt/dsi/runtime/wlp/bin/server create $DSI_TEMPLATE --template=$DSI_TEMPLATE || echo "$DSI_TEMPLATE was already created"
         echo "WLP server $DSI_TEMPLATE has been created"
 

--- a/dsi-runtime/updateserverenv.sh
+++ b/dsi-runtime/updateserverenv.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# This script is called at build time to update /opt/dsi/runtime/wlp/etc/server.env
+# and point to the right JAVA_HOME.
+
+
+set -e
+
+DSI_HOME="/opt/dsi"
+
+if [ -z "$JAVA_HOME" ]; then
+        export JAVA_HOME="$DSI_HOME/jdk/jre"
+fi
+
+echo "JAVA_HOME=$JAVA_HOME"
+
+
+echo "JAVA_HOME=$JAVA_HOME" > /opt/dsi/runtime/wlp/etc/server.env
+


### PR DESCRIPTION
Update wlp/etc/server.env at build time, so that you can call wlp/bin/server create a build time

when deriving images from this DSI image.